### PR TITLE
Remove the correct Python `EXTERNALLY-MANAGED` file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
     && apt-get clean
 
 # Allow installing stuff to system Python.
-RUN rm --force /usr/lib/python3.11/EXTERNALLY-MANAGED
+RUN rm --force /usr/lib/python3.12/EXTERNALLY-MANAGED
 
 # Install Ansible via pip.
 RUN pip3 install $pip_packages


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates `Dockerfile` to remove the correct Python `EXTERNALLY-MANAGED` file.

## 💭 Motivation and context ##

The latest Python for Debian Trixie is now 3.12, not 3.11.

Resolves cisagov/skeleton-ansible-role#205.

## 🧪 Testing ##

All automated tests pass.  I verified locally that the failing builds mentioned in cisagov/skeleton-ansible-role#205 pass with the new Docker image.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.