### PR TITLE
Match multiple versions of Python when removing the `EXTERNALLY-MANAGED` file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ RUN apt-get update \
     && rm --force --recursive /usr/share/man \
     && apt-get clean
 
-# Allow installing stuff to system Python.
-RUN rm --force /usr/lib/python3.12/EXTERNALLY-MANAGED
+# Allow installing stuff to system Python. Since Debian Trixie is currently
+# Debian Testing we may have either Python 3.12 or 3.13 so we match for either.
+RUN rm --force /usr/lib/python3.1[23]/EXTERNALLY-MANAGED
 
 # Install Ansible via pip.
 RUN pip3 install $pip_packages


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This adjusts the removal of the `EXTERNALLY-MANAGED` file to match for both Python 3.12 and 3.13 installs.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We have seen Debian Trixie vary between Python 3.12 and 3.13 since it is Debian Testing. Since this has caused issues both creating this image and downstream it makes sense to adjust the Dockerfile to remove the file for whichever version if present when building.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested locally that this worked to build an image.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.